### PR TITLE
Fix score_event compatibility with python 2.7

### DIFF
--- a/trackml/score.py
+++ b/trackml/score.py
@@ -1,4 +1,5 @@
 """TrackML scoring metric"""
+from __future__ import division
 
 __authors__ = ['Sabrina Amrouche', 'David Rousseau', 'Moritz Kiehn',
                'Ilija Vukotic']
@@ -117,7 +118,7 @@ def score_event(truth, submission):
         Proposed hit/track association. Must have hit_id and track_id columns.
     """
     tracks = _analyze_tracks(truth, submission)
-    purity_rec = numpy.divide(tracks['major_nhits'], tracks['nhits'])
-    purity_maj = numpy.divide(tracks['major_nhits'], tracks['major_particle_nhits'])
+    purity_rec = tracks['major_nhits'] / tracks['nhits']
+    purity_maj = tracks['major_nhits'] / tracks['major_particle_nhits']
     good_track = (0.5 < purity_rec) & (0.5 < purity_maj)
     return tracks['major_weight'][good_track].sum()

--- a/trackml/score.py
+++ b/trackml/score.py
@@ -1,5 +1,4 @@
 """TrackML scoring metric"""
-from __future__ import division
 
 __authors__ = ['Sabrina Amrouche', 'David Rousseau', 'Moritz Kiehn',
                'Ilija Vukotic']
@@ -118,7 +117,7 @@ def score_event(truth, submission):
         Proposed hit/track association. Must have hit_id and track_id columns.
     """
     tracks = _analyze_tracks(truth, submission)
-    purity_rec = tracks['major_nhits'] / tracks['nhits']
-    purity_maj = tracks['major_nhits'] / tracks['major_particle_nhits']
+    purity_rec = numpy.true_divide(tracks['major_nhits'], tracks['nhits'])
+    purity_maj = numpy.true_divide(tracks['major_nhits'], tracks['major_particle_nhits'])
     good_track = (0.5 < purity_rec) & (0.5 < purity_maj)
     return tracks['major_weight'][good_track].sum()


### PR DESCRIPTION
issue: score_event method's output in python 2.7 version differs from python 3. 

To reproduce run code from https://www.kaggle.com/mikhailhushchyn/dbscan-benchmark/ or https://www.kaggle.com/mikhailhushchyn/hough-transform/

This small changes fixes difference.