### PR TITLE
Version 3: phase 2 dataset support and utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,10 @@ TrackML utility library
 =======================
 
 A python library to simplify working with the
-[High Energy Physics Tracking Machine Learning challenge][kaggle_trackml]
-dataset.
+[High Energy Physics Tracking Machine Learning challenge][trackml]
+dataset. It can be used for the datasets of both the
+[accuracy phase][trackml_kaggle] and the
+[throughput phase][trackml_codalab].
 
 Installation
 ------------
@@ -51,6 +53,23 @@ for event_id, hits, cells, particles, truth in load_dataset('path/to/dataset'):
     ...
 ```
 
+To read a single event and compute additional columns derived from the
+stored data:
+
+```python
+from trackml.dataset import load_event
+from trackml.utils import add_position_quantities, add_momentum_quantities, decode_particle_id
+
+# get the particles data
+particles = load_event('path/to/event000000123', parts=['particles'])
+# decode particle id into vertex id, generation, etc.
+particles = decode_particle_id(particles)
+# add vertex rho, phi, r
+particles = add_position_quantities(particles, prefix='v')
+# add momentum eta, p, pt
+particles = add_momentum_quantities(particles)
+```
+
 The dataset path can be the path to a directory or to a zip file containing the
 events `.csv` files. Each event is lazily loaded during the iteration. Options
 are available to read only a subset of available events or only read selected
@@ -73,47 +92,45 @@ look at the function docstrings for detailed information.
 Authors
 -------
 
+The library was written by
+
+*   Moritz Kiehn
+
+with contributions from
+
+*   Sabrina Amrouche
 *   David Rousseau
 *   Ilija Vukotic
-*   Moritz Kiehn
-*   Sabrina Amrouche
+*   Nimar Arora
+*   Jon Nordby
+*   Yerkebulan Berdibekov
+*   Victor Estrade
 
 License
 -------
 
 All code is licensed under the [MIT license][mit_license].
 
-Files
------
-
-The following files are available for the participants:
-
-*   **sample_submission.zip**: a sample submission file with score zero.
-*   **test.zip**: the test dataset with 125 events; the basis for all
-    submissions.
-*   **train_{1,2,3,4,5}.zip**: the full training dataset with 8850 events split
-    into 5 files for convenience.
-*   **train_sample.zip**: the first 100 events from the training dataset.
-*   **detectors.zip**: additional detector geometry information.
-
 Dataset
 -------
 
-A dataset comprises multiple independent events, where each event contains
-simulated measurements (essentially 3D points) of particles generated in a collision between proton
-bunches at the [Large Hadron Collider][lhc] at [CERN][cern]. The goal of the
-tracking machine learning challenge is to group the recorded measurements or
-hits for each event into tracks, sets of hits that belong to the same initial
-particle. A solution must uniquely associate each hit to one track.
-The training dataset contains the recorded
-hits, their ground truth counterpart and their association to particles, and the
-initial parameters of those particles. The test dataset contains only the
+A dataset comprises multiple independent events, where each event
+contains simulated measurements (essentially 3D points) of particles
+generated in a collision between proton bunches at the
+[Large Hadron Collider][lhc] at [CERN][cern]. The goal of the tracking
+machine learning challenge is to group the recorded measurements or hits
+for each event into tracks, sets of hits that belong to the same initial
+particle. A solution must uniquely associate each hit to one track. The
+training dataset contains the recorded hits, their ground truth
+counterpart and their association to particles, and the initial
+parameters of those particles. The test dataset contains only the
 recorded hits.
 
-Once unzipped, the dataset is provided as a set of plain `.csv` files. Each
-event has four associated files that contain hits, hit cells, particles, and the
-ground truth association between them. The common prefix, e.g. `event000000010`,
-is always `event` followed by 9 digits.
+Each dataset is usually provided as a single archive file. Once
+unzipped, the dataset comprises a set of `.csv[.gz]` files. Each event
+can have up to four associated files that contain hits, hit cells,
+particles, and the ground truth association between them. The common
+prefix, e.g. `event000000010`, is always `event` followed by 9 digits.
 
     event000000000-hits.csv
     event000000000-cells.csv
@@ -124,8 +141,8 @@ is always `event` followed by 9 digits.
     event000000001-particles.csv
     event000000001-truth.csv
 
-Submissions must be provided as a single `.csv` file for the whole dataset with
-a name starting with `submission`, e.g.
+Submissions must be provided as a single `.csv` file for the whole
+dataset, e.g.
 
     submission-test.csv
     submission-final.csv
@@ -169,9 +186,9 @@ particle.
 The particles files contains the following values for each particle/entry:
 
 *   **particle_id**: numerical identifier of the particle inside the event.
-*   **particle_type**: numerical identifier of the particle type;
-    numbering scheme is the
-    [Particle Data Group Monte Carlo numbering scheme](pdg_mc_numbering).
+*   **particle_type**: numerical identifier of the particle type; the
+    [Particle Data Group Monte Carlo numbering scheme][pdg_mc_numbering]
+    is used to identify specific particle types.
 *   **vx, vy, vz**: initial position or vertex (in millimeters) in global
     coordinates.
 *   **px, py, pz**: initial momentum (in GeV/c) along each global axis.
@@ -185,7 +202,7 @@ All entries contain the generated information or ground truth.
 The cells file contains the constituent active detector cells that comprise each
 hit. The cells can be used to refine the hit to track association.
 A cell is the smallest granularity inside each detector module, much like a
-pixel on a screen, except that depending on the volume_id a cell can be a square
+pixel on a screen, except that depending on the **volume_id** a cell can be a square
 or a long rectangle. It is identified by two channel identifiers that are unique
 within each detector module and encode the position, much like column/row
 numbers of a matrix. A cell can provide signal information that the detector
@@ -202,9 +219,7 @@ the value might have different resolution.
 
 The submission file must associate each hit in each event to one and only one
 reconstructed particle track. The reconstructed tracks must be uniquely
-identified only within each event.  Participants are advised to compress the
-submission file (with zip, bzip2, gzip) before submission to the
-[Kaggle site][kaggle_trackml].
+identified only within each event.
 
 *   **event_id**: numerical identifier of the event; corresponds to the number
     found in the per-event file name prefix.
@@ -218,10 +233,10 @@ submission file (with zip, bzip2, gzip) before submission to the
 The detector is built from silicon slabs (or modules, rectangular or
 trapezoïdal), arranged in cylinders and disks, which measure the position (or
 hits) of the particles that cross them. The detector modules are organized
-into detector groups or volumes identified by a volume id. Inside a volume they
-are further grouped into layers identified by a layer id. Each layer can contain
+into detector groups or volumes identified by a **volume_id**. Inside a volume they
+are further grouped into layers identified by a **layer_id**. Each layer can contain
 an arbitrary number of detector modules, the smallest geometrically distinct
-detector object, each identified by a module_id. Within each group, detector
+detector object, each identified by a **module_id**. Within each group, detector
 modules are of the same type have e.g. the same granularity. All simulated
 detector modules are so-called semiconductor sensors that are build from thin
 silicon sensor chips. Each module can be represented by a two-dimensional,
@@ -262,5 +277,7 @@ an offset.
 [cern]: https://home.cern
 [lhc]: https://home.cern/topics/large-hadron-collider
 [mit_license]: http://www.opensource.org/licenses/MIT
-[kaggle_trackml]: https://www.kaggle.com/c/trackml-particle-identification
+[trackml]: https://sites.google.com/site/trackmlparticle/
+[trackml_kaggle]: https://www.kaggle.com/c/trackml-particle-identification
+[trackml_codalab]: https://competitions.codalab.org/competitions/20112
 [pdg_mc_numbering]: http://pdg.lbl.gov/2018/reviews/rpp2018-rev-monte-carlo-numbering.pdf

--- a/README.md
+++ b/README.md
@@ -169,6 +169,9 @@ particle.
 The particles files contains the following values for each particle/entry:
 
 *   **particle_id**: numerical identifier of the particle inside the event.
+*   **particle_type**: numerical identifier of the particle type;
+    numbering scheme is the
+    [Particle Data Group Monte Carlo numbering scheme](pdg_mc_numbering).
 *   **vx, vy, vz**: initial position or vertex (in millimeters) in global
     coordinates.
 *   **px, py, pz**: initial momentum (in GeV/c) along each global axis.
@@ -260,3 +263,4 @@ an offset.
 [lhc]: https://home.cern/topics/large-hadron-collider
 [mit_license]: http://www.opensource.org/licenses/MIT
 [kaggle_trackml]: https://www.kaggle.com/c/trackml-particle-identification
+[pdg_mc_numbering]: http://pdg.lbl.gov/2018/reviews/rpp2018-rev-monte-carlo-numbering.pdf

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with io.open(op.join(here, 'README.md'), mode='rt', encoding='utf-8') as f:
 
 setup(
     name='trackml',
-    version='3.dev',
+    version='3',
     description='TrackML utility library',
     long_description=long_description,
     long_description_content_type='text/markdown',

--- a/trackml/dataset.py
+++ b/trackml/dataset.py
@@ -59,6 +59,7 @@ DEFAULT_PARTS = ['hits', 'cells', 'particles', 'truth']
 def _load_event_data(prefix, name):
     """Load per-event data for one single type, e.g. hits, or particles.
     """
+    # csv files can be individually zipped with extension .csv.gz
     expr = '{!s}-{}.csv*'.format(prefix, name)
     files = glob.glob(expr)
     dtype = DTYPES[name]
@@ -144,7 +145,7 @@ def load_dataset(path, skip=None, nevents=None, parts=DEFAULT_PARTS):
             prefixes = prefixes[:nevents]
         return prefixes
 
-    # TODO use yield from when we increase the python requirement
+    # TODO use `yield from` once we increase the python requirement
     if op.isdir(path):
         for x in _iter_dataset_dir(path, list_prefixes(os.listdir(path)), parts):
             yield x
@@ -154,10 +155,11 @@ def load_dataset(path, skip=None, nevents=None, parts=DEFAULT_PARTS):
                 yield x
 
 def _extract_event_id(prefix):
-    """Extract event_id from prefix, e.g. event_id=1 from `event000000001`
-    or from `train_1/event000000001`
+    """Extract event_id from prefix.
+
+    E.g. event_id=1 from `event000000001` or from `train_1/event000000001`
     """
-    regex = r".*event(\d+)"
+    regex = r'.*event(\d+)'
     groups = re.findall(regex, prefix)
     return int(groups[0])
 

--- a/trackml/dataset.py
+++ b/trackml/dataset.py
@@ -27,6 +27,7 @@ HITS_DTYPES = dict([
 ])
 PARTICLES_DTYPES = dict([
     ('particle_id', 'i8'),
+    ('particle_type', 'i4'),
     ('vx', 'f4'),
     ('vy', 'f4'),
     ('vz', 'f4'),

--- a/trackml/utils.py
+++ b/trackml/utils.py
@@ -1,0 +1,46 @@
+"""TrackML utility functions"""
+
+__authors__ = ['Moritz Kiehn']
+
+import numpy as np
+
+def add_position_quantities(data, prefix=''):
+    """Add derived position quantities rho, phi, and r.
+    """
+    x = data['{}x'.format(prefix)]
+    y = data['{}y'.format(prefix)]
+    z = data['{}z'.format(prefix)]
+    t = np.hypot(x, y)
+    data['{}rho'.format(prefix)] = t
+    data['{}phi'.format(prefix)] = np.arctan2(y, x)
+    data['{}r'.format(prefix)] = np.hypot(t, z)
+    return data
+
+def add_momentum_quantities(data, prefix=''):
+    """Add derived momentum quantities pt, pphi, peta, p.
+    """
+    px = data['{}px'.format(prefix)]
+    py = data['{}py'.format(prefix)]
+    pz = data['{}pz'.format(prefix)]
+    pt = np.hypot(px, py)
+    p = np.hypot(pt, pz)
+    data['{}pt'.format(prefix)] = pt
+    data['{}pphi'.format(prefix)] = np.arctan2(py, px)
+    data['{}peta'.format(prefix)] = np.arctanh(pz / p)
+    data['{}p'.format(prefix)] = p
+    return data
+
+def decode_particle_id(data):
+    """Decode particle_id into vertex id, generation, etc.
+    """
+    components = [
+        ('vertex_id',    0xfff0000000000000, 13 * 4),
+        ('primary_id',   0x000ffff000000000, 9 * 4),
+        ('generation',   0x0000000fff000000, 6 * 4),
+        ('secondary_id', 0x0000000000fff000, 3 * 4),
+        ('process',      0x0000000000000fff, 0),
+    ]
+    pid = data['particle_id'].values.astype('u8')
+    for name, mask, shift in components:
+        data[name] = (pid & mask) >> shift
+    return data

--- a/trackml/weights.py
+++ b/trackml/weights.py
@@ -77,8 +77,8 @@ def weight_pt(pt, pt_inf=0.5, pt_sup=3, w_min=0.2, w_max=1.):
 # particle id for noise hits
 INVALID_PARTICLED_ID = 0
 
-def weight_hits(truth, particles):
-    """Compute per-hit weights for the scoring metric.
+def weight_hits_phase1(truth, particles):
+    """Compute per-hit weights for the phase 1 scoring metric.
 
     Hits w/ invalid particle ids, e.g. noise hits, have zero weight.
 

--- a/trackml/weights.py
+++ b/trackml/weights.py
@@ -9,6 +9,8 @@ import math
 import numpy
 import pandas
 
+from .utils import decode_particle_id
+
 def _compute_order_weight_matrix(proposal, min_hits, max_hits):
     """Compute the hit order weight matrix.
 
@@ -122,6 +124,60 @@ def weight_hits_phase1(truth, particles):
     w = combined['weight_pt'] * combined['weight_order']
     w /= w.sum()
     combined['weight'] = w
+
+    # return w/o intermediate columns
+    return combined.drop(columns=['particle_vz', 'abs_dvz'])
+
+def weight_hits_phase2(truth, particles):
+    """Compute per-hit weights for the phase 2 scoring metric.
+
+    This is the phase 1 metric with an additional particle preselection, i.e.
+    only a subset of the particles have a non-zero score.
+
+    Parameters
+    ----------
+    truth : pandas.DataFrame
+        Truth information. Must have hit_id, particle_id, and tz columns.
+    particles : pandas.DataFrame
+        Particle information. Must have particle_id, vz, px, py, and nhits
+        columns.
+
+    Returns
+    -------
+    pandas.DataFrame
+        `truth` augmented with additional columns: particle_nhits, ihit,
+        weight_order, weight_pt, and weight.
+    """
+    # fill selected per-particle information for each hit
+    selected = pandas.DataFrame({
+        'particle_id': particles['particle_id'],
+        'particle_vz': particles['vz'],
+        'particle_nhits': particles['nhits'],
+        'weight_pt': weight_pt(numpy.hypot(particles['px'], particles['py'])),
+    })
+    selected = decode_particle_id(selected)
+    combined = pandas.merge(truth, selected,
+                            how='left', on=['particle_id'],
+                            validate='many_to_one')
+
+    # fix pt weight for hits w/o associated particle
+    combined['weight_pt'].fillna(0.0, inplace=True)
+    # fix nhits for hits w/o associated particle
+    combined['particle_nhits'].fillna(0.0, inplace=True)
+    combined['particle_nhits'] = combined['particle_nhits'].astype('i4')
+
+    # compute hit count and order using absolute distance from particle vertex
+    combined['abs_dvz'] = numpy.absolute(combined['tz'] - combined['particle_vz'])
+    combined['ihit'] = combined.groupby('particle_id')['abs_dvz'].rank().transform(lambda x: x - 1).fillna(0.0).astype('i4')
+    # compute order-dependent weight
+    combined['weight_order'] = combined[['ihit', 'particle_nhits']].apply(weight_order, axis=1)
+
+    # compute normalized combined weight w/ extra particle selection
+    weight = combined['weight_pt'] * combined['weight_order']
+    weight[combined['generation'] != 0] = 0
+    weight /= weight.sum()
+    # normalize total event weight
+    combined['weight'] = weight
 
     # return w/o intermediate columns
     return combined.drop(columns=['particle_vz', 'abs_dvz'])


### PR DESCRIPTION
* Add support for phase 2 hit weight that ignores non-primary particles.
* Add support for `particle_type` column in phase 2 dataset.
* Add utilities to decode `particle_id` and add derived position and momentum quantities.
* Documentation cleanup.